### PR TITLE
インラインのcheck_box_groupがうまく働かないバグと表示に自動エスケープされてしまう問題

### DIFF
--- a/lib/selectable_attr_rails/helpers/check_box_group_helper.rb
+++ b/lib/selectable_attr_rails/helpers/check_box_group_helper.rb
@@ -49,7 +49,7 @@ module SelectableAttrRails::Helpers
             result << builder.label
             result << '&nbsp;'
           end
-          return result.html_safe
+          return result.respond_to?(:html_safe) ? result.html_safe : result
         end
       end
     end

--- a/lib/selectable_attr_rails/helpers/check_box_group_helper.rb
+++ b/lib/selectable_attr_rails/helpers/check_box_group_helper.rb
@@ -37,7 +37,7 @@ module SelectableAttrRails::Helpers
     module Base
       def check_box_group(object_name, method, options = nil, &block)
         object = (options || {})[:object] || instance_variable_get("@#{object_name}")
-        builder = Builder.new(object, object_name, method, options, @template)
+        builder = Builder.new(object, object_name, method, options, self)
         if block_given?
           yield(builder)
           return nil

--- a/lib/selectable_attr_rails/helpers/check_box_group_helper.rb
+++ b/lib/selectable_attr_rails/helpers/check_box_group_helper.rb
@@ -49,7 +49,7 @@ module SelectableAttrRails::Helpers
             result << builder.label
             result << '&nbsp;'
           end
-          return result
+          return result.html_safe
         end
       end
     end

--- a/lib/selectable_attr_rails/helpers/radio_button_group_helper.rb
+++ b/lib/selectable_attr_rails/helpers/radio_button_group_helper.rb
@@ -44,7 +44,7 @@ module SelectableAttrRails::Helpers
             result << builder.radio_button
             result << builder.label
           end
-          return result
+          return result.html_safe
         end
       end
     end

--- a/lib/selectable_attr_rails/helpers/radio_button_group_helper.rb
+++ b/lib/selectable_attr_rails/helpers/radio_button_group_helper.rb
@@ -44,7 +44,7 @@ module SelectableAttrRails::Helpers
             result << builder.radio_button
             result << builder.label
           end
-          return result.html_safe
+          return result.respond_to?(:html_safe) ? result.html_safe : result
         end
       end
     end


### PR DESCRIPTION
Rails3対応が特に明記されていませんが、現在Rails3でも利用させてもらっています。

すべての動作を確認していませんが、一部でエラーとなりました。
@templateがnilのため

```
undefined method `content_tag' for nil:NilClass
```

というエラーになってしまうので、radio_button_groupのように対応してみました。

また、Rails3でインライン？（ブロック渡しでない）の場合に自動エスケープされてしまいました。
これを解除するためには、rawやhtml_safeがあると思いますが、他のヘルパーを参考にhtml_safeを用いてみました。

ただし、このエスケープ解除をプラグイン側で対応するのか、利用側で対応すべきなのかはちょっとわからないのですが、他のフォームヘルパーと合わせてプラグイン側で対応した方がいいのかなと思いました。

P.S.
すいません。単純にコメントでもよかったのですが、プルリクエストを試してみたかったので、このような形をとらせて頂きました。
