### PR TITLE
FIX undefined method `alias_method_chain' for Ruby 2

### DIFF
--- a/lib/selectable_attr_rails/helpers/select_helper.rb
+++ b/lib/selectable_attr_rails/helpers/select_helper.rb
@@ -3,7 +3,13 @@ module SelectableAttrRails::Helpers
     module Base
       def self.included(base)
         base.module_eval do
-          alias_method_chain :select, :attr_enumeable
+          if RUBY_VERSION >= '2.0.0'
+            alias_method :select_without_attr_enumeable, :select
+            alias_method :select, :select_with_attr_enumeable
+            prepend SelectableAttrRails::Helpers::SelectHelper::Base
+          else
+            alias_method_chain :select, :attr_enumeable
+          end
         end
       end
 
@@ -55,7 +61,12 @@ module SelectableAttrRails::Helpers
     module FormBuilder
       def self.included(base)
         base.module_eval do
-          alias_method_chain :select, :attr_enumeable
+          if RUBY_VERSION >= '2.0.0'
+            alias_method :select, :select_with_attr_enumeable
+            prepend SelectableAttrRails::Helpers::SelectHelper::FormBuilder
+          else
+            alias_method_chain :select, :attr_enumeable
+          end
         end
       end
 

--- a/lib/selectable_attr_rails/helpers/select_helper.rb
+++ b/lib/selectable_attr_rails/helpers/select_helper.rb
@@ -3,7 +3,12 @@ module SelectableAttrRails::Helpers
     module Base
       def self.included(base)
         base.module_eval do
-          alias_method_chain :select, :attr_enumeable
+          if RUBY_VERSION >= '2.0.0'
+            alias_method :select, :select_with_attr_enumeable
+            prepend SelectableAttrRails::Helpers::SelectHelper::Base
+          else
+            alias_method_chain :select, :attr_enumeable
+          end
         end
       end
 
@@ -55,7 +60,12 @@ module SelectableAttrRails::Helpers
     module FormBuilder
       def self.included(base)
         base.module_eval do
-          alias_method_chain :select, :attr_enumeable
+          if RUBY_VERSION >= '2.0.0'
+            alias_method :select, :select_with_attr_enumeable
+            prepend SelectableAttrRails::Helpers::SelectHelper::FormBuilder
+          else
+            alias_method_chain :select, :attr_enumeable
+          end
         end
       end
 


### PR DESCRIPTION
Rails2 のころから愛用させていただいております。
この度 5.1 へのバージョンアップ時に起動しなくなりましたので、拙いながらもプルリクエストを出させていただきました。